### PR TITLE
Bug fixes related to the use of myloasm and minor README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 Strain-level metagenomic classification with Metagenome Assembly driven Database Reduction approach
 
++ [Why MADRe?](#why-madre)
++ [Installation](#installation)
++ [Build database](#build-database)
++ [How to run MADRe?](#how-to-run-madre)
++ [Run specific steps](#run-specific-steps)
++ [Abundance calculation](#abundance-calculation)
++ [Citing MADRe](#citing-madre)
+
 ## Why MADRe?
 
 **MADRe (Metagenomic Assembly-Driven Database Reduction)** is designed for metagenomic analyses where there is **no prior knowledge about the sample composition** and the starting database is **large and diverse**, containing thousands of species and strains.
@@ -29,7 +37,7 @@ Use MADRe when working with:
 
 MADRe is particularly useful as a **first-pass classification tool** for large, uncharacterized metagenomic datasets, providing a computationally efficient and biologically meaningful starting point for deeper strain-level analysis.
 
-## Instalation
+## Installation
 
 ### OPTION 1 : Conda
 
@@ -60,6 +68,7 @@ more information:
 ```
 madre --help
 ```
+
 ### OPTION 2: Running from source
 
 ```
@@ -109,16 +118,15 @@ more information:
 python MADRe.py --help
 ```
 
-
-
-Recommended database is Kraken2 bacteria database - instructions on how to build it you can find under the section [Build database](#build-database).
+The recommended database is Kraken2 bacteria database - instructions on how to build it you can find under the section [Build database](#build-database).
 
 Information on how to run specific MADRe steps find under the section [Run specific steps](#run-specific-steps).
+</details>
 
 ## Build database
 
 ### Recommended database (kraken2 built database)
-Recommend database is the kraken2 built bacteria database following next steps:
+The recommend database is the kraken2 built bacteria database following next steps:
 ```
 kraken2-build --download-taxonomy --db $DBNAME
 kraken2-build --download-library bacteria --db $DBNAME
@@ -156,7 +164,7 @@ MADRe for species-level classification step uses taxids index. For building new 
 
 ## How to run MADRe?
 
-This README contains basic information on how to run MADRe pipeline. However, **for more detailed tuorial check [toy_example/Tutorial.md](https://github.com/lbcb-sci/MADRe/blob/main/toy_example/Tutorial.md) file**.
+This README contains basic information on how to run MADRe pipeline. However, **for a more detailed tuorial check [toy_example/Tutorial.md](https://github.com/lbcb-sci/MADRe/blob/main/toy_example/Tutorial.md) file**.
 
 ## Run specific steps
 
@@ -226,7 +234,7 @@ The default output is rc_abundances.out containing read count abundances. If you
 If you want to calculate cluster abundances, you need to provide path to the directory containing ```clusters.txt``` and ```representatives.txt``` files. In that case output files will contain only represetative references with sumarized abundances for cluster that reference is represetative of.
 
 ## Citing MADRe
-bioRxiv preprint - https://www.biorxiv.org/content/10.1101/2025.05.12.653324v1:
+bioRxiv preprint - https://www.biorxiv.org/content/10.1101/2025.05.12.653324:
 ```
 Lipovac, J., Sikic, M., Vicedomini, R., & Krizanovic, K. (2025). MADRe: Strain-Level Metagenomic Classification Through Assembly-Driven Database Reduction. bioRxiv, 2025-05.
 ```

--- a/src/MADRe.py
+++ b/src/MADRe.py
@@ -41,14 +41,14 @@ def main():
     parser.add_argument("--strictness", type=str, default="very-strict", choices=["less-strict", "strict", "very-strict"], help="Database reduction strictness level. (default=very-strict)")
     parser.add_argument("--collapsed_strains_overhead", type=int, default=MAX_COLLAPSED_STRAINS_OVERHEAD, help="Overhead for collapsed strains during database reduction. (default=" + str(MAX_COLLAPSED_STRAINS_OVERHEAD) + ")")
     parser.add_argument("--min_contig_len", type=int, default=MIN_CONTIG_LEN, help="Minimum contig length for database reduction. (default=" + str(MIN_CONTIG_LEN) + ")")
-    parser.add_argument("--use-myloasm", type=bool, default=False, help="Use Myloasm assembler tool instead of metaFlye/metaMDBG. (default=False)")
+    parser.add_argument("--use-myloasm", action='store_true', help="Use Myloasm assembler instead of metaFlye/metaMDBG.")
 
     args = parser.parse_args()
 
     logging.info("Starting MADRe...")
     logging.info(f"Configuration: {args.config}")
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(inline_comment_prefixes=('#',))
     config.read(args.config)
 
     PATH_METAFLYE = config["PATHS"]["metaflye"]

--- a/toy_example/Tutorial.md
+++ b/toy_example/Tutorial.md
@@ -22,7 +22,7 @@ strain_species_json = MADRe/database/taxids_species.json
 For more information about MADRe’s pipeline parameters:
 ```
 $ madre --help
-usage: madre [-h] [--version] --out-folder OUT_FOLDER --reads READS [--reads_flag {pacbio,hifi,ont}] [--threads THREADS] [-F] [--config CONFIG] [--strictness {less-strict,strict,very-strict}] [--collapsed_strains_overhead COLLAPSED_STRAINS_OVERHEAD] [--min_contig_len MIN_CONTIG_LEN]
+usage: madre [-h] [--version] --out-folder OUT_FOLDER --reads READS [--reads_flag {pacbio,hifi,ont}] [--threads THREADS] [-F] [--config CONFIG] [--strictness {less-strict,strict,very-strict}] [--collapsed_strains_overhead COLLAPSED_STRAINS_OVERHEAD] [--min_contig_len MIN_CONTIG_LEN] [--use-myloasm]
 
 MADRe
 
@@ -43,14 +43,14 @@ optional arguments:
                         Overhead for collapsed strains during database reduction. (default=2)
   --min_contig_len MIN_CONTIG_LEN
                         Minimum contig length for database reduction. (default=1000)
-  --use-myloasm USE_MYLOASM
-                        Use Myloasm assembler tool instead of metaFlye/metaMDBG. (default=False)
+  --use-myloasm         Use Myloasm assembler instead of metaFlye/metaMDBG.
+
 ```
 
 Once the `config.ini` file is ready, you can run the full pipeline with:
 
 ```
-$ madre --out-folder MADRe_toy_example --reads sim_small.fastq.gz --reads_flag ont --threads 32 --config.ini ./config.ini --strictness very-strict --collapsed_strains_overhead 2 --min_contig_len 1000 --use_myloasm False
+$ madre --out-folder MADRe_toy_example --reads sim_small.fastq.gz --reads_flag ont --threads 32 --config ./config.ini --strictness very-strict --collapsed_strains_overhead 2 --min_contig_len 1000
 ```
 
 Detailed information about additional MADRe parameters can be found in the [Additional parameters information](#additional-parameters-information) section.


### PR DESCRIPTION
### Bug fixes
- Modified parameter `--use-myloasm` to be used as a flag (`False` by default, set to `True` only if provided on the command line). Previous definition did not work properly (myloasm was called even when providing `--use-myloasm False`).
- The example/default `config.ini` file is not parsed correctly for myloasm due to an unhandled inline comment. I added the possiblity to use inline comments using the `#` character.
- Updated Tutorial.md with the different usage of `--use-myloasm`

### README.md modifications
- Added a list at the top to jump directly to main sections
- Minor English corrections